### PR TITLE
Migration for text-type field and without index

### DIFF
--- a/lib/generators/translateable/templates/migration.rb.erb
+++ b/lib/generators/translateable/templates/migration.rb.erb
@@ -13,11 +13,13 @@ class MigrateTranslateable<%= table_name.camelize + field_name.camelize %> < Act
         SQL
         remove_column :<%= table_name %>, :<%= field_name %>
         rename_column :<%= table_name %>, :<%= field_name + '_t' %>, :<%= field_name %>
+        <% if index_exists?(table_name, field_name) %>
         add_index :<%= table_name %>, :<%= field_name %>, using: :gin
+        <% end %>
       end
 
       dir.down do
-        add_column :<%= table_name %>, :<%= field_name + '_t' %>, :string, null: false, default: ''
+        add_column :<%= table_name %>, :<%= field_name + '_t' %>, <%= field_type || ':string' %>, null: false, default: ''
         execute <<-SQL
         UPDATE <%= table_name %> AS m1
         SET <%= field_name + '_t' %> = (
@@ -26,7 +28,9 @@ class MigrateTranslateable<%= table_name.camelize + field_name.camelize %> < Act
         SQL
         remove_column :<%= table_name %>, :<%= field_name %>
         rename_column :<%= table_name %>, :<%= field_name + '_t' %>, :<%= field_name %>
+        <% if index_exists?(table_name, field_name) %>
         add_index :<%= table_name %>, :<%= field_name %>
+        <% end %>
       end
     end
   end


### PR DESCRIPTION
This change should make it possible to create good migrations when the field is of type text and does not have an index on it. It would be pure madness to generate an extra index in such cases. And forcing the Down migration into type String may lose data.